### PR TITLE
Allow for situations where tmux is a process but not active 

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ if ! tmux has-session -t=$selected_name 2> /dev/null; then
     tmux new-session -ds $selected_name -c $selected
 fi
 
-tmux switch-client -t $selected_name
+if [[ -z $TMUX ]]; then
+    tmux attach -t $selected_name
+else
+    tmux switch-client -t $selected_name
+fi
 ```
 
 - Here change the find paths on line no. 6 to your corresponding paths to projects folder on which you want to work on


### PR DESCRIPTION
This Solves a bug where you would not active any tmux session if you have a tmux process but not active client (e.g., just recently detached or immediately after login with the aid after tmux-continuum and tmux-resurrect).